### PR TITLE
Removed mandatory language arguments

### DIFF
--- a/json2po.sh
+++ b/json2po.sh
@@ -22,7 +22,7 @@ fi
 
 cp -r www/i18n "$tmp_file/lang"
 pushd "$tmp_file/lang"&&
-	for i in `ls !(en.json)`;do cp en.json $i;done&&
+	for i in `ls !(en).json`;do cp en.json $i;done&&
 popd
 
 git checkout "$current_branch"
@@ -33,7 +33,7 @@ fi
 ./po2json.sh "$included_languages" "$tmp_file/old_po"
 json2po -t "$tmp_file/lang" "$tmp_file/old_po" "$tmp_file/new_po"
 pushd www/translation&&
-	for i in `ls !(en.json)`; do msgmerge -U $i "$tmp_file/new_po/$i"; done&&
+	for i in `ls !(en).json`; do msgmerge -U $i "$tmp_file/new_po/$i"; done&&
 popd
 git add www/translation/*.po
 rm www/translation/*.po~

--- a/json2po.sh
+++ b/json2po.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # install translation toolkit first: http://translate-toolkit.readthedocs.org/en/latest/index.html
+#set -x
 shopt -s extglob
-included_languages="ar,de,en,es,fr,id,it,pl,pt,ru,vi,zh_cn,zh_tw,it"
 if [ ! -e "po2json.sh" ]; then
 	echo "Error: This script needs the po2json.sh as its dependency"
 	exit 1
@@ -30,13 +30,14 @@ if [ $stashed -eq 1 ]; then
 	git stash pop
 fi
 
-./po2json.sh "$included_languages" "$tmp_file/old_po"
+./po2json.sh "$tmp_file/old_po"
 json2po -t "$tmp_file/lang" "$tmp_file/old_po" "$tmp_file/new_po"
 pushd www/translation&&
-	for i in `ls !(en).json`; do msgmerge -U $i "$tmp_file/new_po/$i"; done&&
+	for i in `ls !(en).po`; do msgmerge -U $i "$tmp_file/new_po/$i"; done&&
 popd
 git add www/translation/*.po
 rm www/translation/*.po~
 git commit -m "Updated translation files with the recent changes - `date +'%y%m%d'`"
 
 shopt -u extglob
+#set +x

--- a/po2json.sh
+++ b/po2json.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # install translation toolkit first: http://translate-toolkit.readthedocs.org/en/latest/index.html
-#set -x
+set -x
 shopt -s extglob
 completed_langs="$1"
 all_languages=false
@@ -41,18 +41,18 @@ if [ "$mode" == "INCLUSIVE" ]; then
 fi
 po2json -t "$tmp_file/i18n" "$tmp_file/translation" "$tmp_file"
 if [ "$mode" == "INCLUSIVE" ]; then
-	test all_languages == false && eval "cp $tmp_file/$completed_langs.json www/i18n"
-	test all_languages == true && cp "$tmp_file/"!(en).json www/i18n
-	test all_languages == false && eval "git add www/i18n/$completed_langs.json"
-	test all_languages == true && git add www/i18n/!(en).json
+	test $all_languages == false && eval "cp $tmp_file/$completed_langs.json www/i18n"
+	test $all_languages == true && cp "$tmp_file/"!(en).json www/i18n
+	test $all_languages == false && eval "git add www/i18n/$completed_langs.json"
+	test $all_languages == true && git add www/i18n/!(en).json
 	git commit -m "Converted translation files to json - `date +'%y%m%d'`"
 else
-	test all_languages == false && eval "cp $tmp_file/$completed_langs.json $dst"
-	test all_languages == true && cp "$tmp_file/"!(en).json "$dst"
+	test $all_languages == false && eval "cp $tmp_file/$completed_langs.json $dst"
+	test $all_languages == true && cp "$tmp_file/"!(en).json "$dst"
 fi
 git checkout "$current_branch"
 if [ $stashed -eq 1 ]; then 
 	git stash pop
 fi
 shopt -u extglob
-#set +x
+set +x

--- a/po2json.sh
+++ b/po2json.sh
@@ -5,8 +5,11 @@ shopt -s extglob
 completed_langs="$1"
 all_languages=false
 dst="$2"
-if [ -z "$completed_langs" ] ;then
+if [ -z "$completed_langs" -a ! -e "$completed_langs" ] ;then
 	all_languages=true
+elif [ -e "$completed_langs" ] ;then
+	all_languages=true
+	dst="$completed_langs"
 else
 	echo "$completed_langs"| grep -q , && completed_langs="{$completed_langs}"
 fi

--- a/po2json.sh
+++ b/po2json.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # install translation toolkit first: http://translate-toolkit.readthedocs.org/en/latest/index.html
-set -x
+#set -x
 shopt -s extglob
 completed_langs="$1"
 all_languages=false
@@ -58,4 +58,4 @@ if [ $stashed -eq 1 ]; then
 	git stash pop
 fi
 shopt -u extglob
-set +x
+#set +x

--- a/po2json.sh
+++ b/po2json.sh
@@ -21,7 +21,7 @@ fi
 function make_new_templates(){
 	cp -r www/i18n "$tmp_file"
 	pushd "$tmp_file/i18n"&&
-		for i in `ls !(en.json)`; do cp en.json $i; done &&
+		for i in `shopt -s extglob && ls !(en).json`; do cp en.json $i; done &&
 	popd
 }
 destination_branch="dev"

--- a/po2json.sh
+++ b/po2json.sh
@@ -21,7 +21,7 @@ fi
 function make_new_templates(){
 	cp -r www/i18n "$tmp_file"
 	pushd "$tmp_file/i18n"&&
-		for i in `shopt -s extglob && ls !(en).json`; do cp en.json $i; done &&
+		for i in `ls !(en).json`; do cp en.json $i; done &&
 	popd
 }
 destination_branch="dev"

--- a/po2json.sh
+++ b/po2json.sh
@@ -3,11 +3,10 @@
 #set -x
 shopt -s extglob
 completed_langs="$1"
+all_languages=false
 dst="$2"
 if [ -z "$completed_langs" ] ;then
-	echo "Error: completed languages cannot be empty"
-	echo "Usage Example: ./po2json.sh id,cn"
-	exit 1
+	all_languages=true
 else
 	echo "$completed_langs"| grep -q , && completed_langs="{$completed_langs}"
 fi
@@ -42,11 +41,14 @@ if [ "$mode" == "INCLUSIVE" ]; then
 fi
 po2json -t "$tmp_file/i18n" "$tmp_file/translation" "$tmp_file"
 if [ "$mode" == "INCLUSIVE" ]; then
-	eval "cp $tmp_file/$completed_langs.json www/i18n"
-	eval "git add www/i18n/$completed_langs.json"
+	test all_languages == false && eval "cp $tmp_file/$completed_langs.json www/i18n"
+	test all_languages == true && cp "$tmp_file/"!(en).json www/i18n
+	test all_languages == false && eval "git add www/i18n/$completed_langs.json"
+	test all_languages == true && git add www/i18n/!(en).json
 	git commit -m "Converted translation files to json - `date +'%y%m%d'`"
 else
-	eval "cp $tmp_file/$completed_langs.json $dst"
+	test all_languages == false && eval "cp $tmp_file/$completed_langs.json $dst"
+	test all_languages == true && cp "$tmp_file/"!(en).json "$dst"
 fi
 git checkout "$current_branch"
 if [ $stashed -eq 1 ]; then 

--- a/www/translation/ru.po
+++ b/www/translation/ru.po
@@ -4,8 +4,8 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-02-22 12:19+0430\n"
-"PO-Revision-Date: 2016-02-23 21:20+0000\n"
-"Last-Translator: Alina Demidova <alinademidova1@gmail.com>\n"
+"PO-Revision-Date: 2016-02-24 05:08+0000\n"
+"Last-Translator: olga borg <olga@binary.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/binary-tick-"
 "trade/app/ru/>\n"
 "Language: ru\n"
@@ -18,7 +18,7 @@ msgstr ""
 
 #: .help.email_cs
 msgid "Have questions? Email customer support at "
-msgstr "У Вас возникли вопросы? Отправьте email службе поддержки\n"
+msgstr "У Вас возникли вопросы? Отправьте email службе поддержки "
 
 #: .help.copy_token
 msgid "and create a token. Then simply copy and paste it into the top box."
@@ -209,7 +209,7 @@ msgstr "Добавить"
 
 #: .accounts.remove_all
 msgid "Remove All Accounts & Sign Out"
-msgstr "Удалить все счета и выйти "
+msgstr "Удалить все счета и выйти"
 
 #: .accounts.new_token
 msgid "Add a new token"
@@ -285,7 +285,7 @@ msgstr "Пожалуйста, введите действующий токен."
 
 #: .alert.remove_all_tokens_content
 msgid "Are you sure you want to remove all tokens and sign out?"
-msgstr "Вы уверены, что хотите удалить все токены и выйти? "
+msgstr "Вы уверены, что хотите удалить все токены и выйти?"
 
 #: .options.even
 msgid "Even"
@@ -306,7 +306,7 @@ msgstr "Forex"
 
 #: .options.lets_trade
 msgid "Let's trade!"
-msgstr ""
+msgstr "Начните торговлю!"
 
 #: .options.digit_match
 msgid "Digit Match"


### PR DESCRIPTION
The po2json doesn't require specified languages to work.
Usage:
1. ./po2json.sh pl,ru (when only Russian and Polish are completed)
2. ./po2json.sh (when all languages are completed)
3. ./po2json.sh /tmp/po (used in json2po.sh script)